### PR TITLE
Abstract permission defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,11 @@ netdata_manage_charts: false
 # Define Netdata config file path
 netdata_config_dir: "/etc/netdata"
 
+# Define our default file ownership for config files (Linux only)
+netdata_config_owner: root
+netdata_config_group: netdata
+netdata_config_mode: '0644'
+
 # Define the Netdata custom config directory
 netdata_custom_config_path: ""
 

--- a/tasks/configure-linux.yml
+++ b/tasks/configure-linux.yml
@@ -2,9 +2,9 @@
   ansible.builtin.template:
     src: "{{ netdata_custom_config_path }}"
     dest: "{{ netdata_config_dir }}/netdata.conf"
-    owner: root
-    group: netdata
-    mode: '0644'
+    owner: "{{ netdata_config_owner }}"
+    group: "{{ netdata_config_group }}"
+    mode: "{{ netdata_config_mode }}"
   when:
     - netdata_manage_config
     - netdata_custom_config_path != ""
@@ -14,9 +14,9 @@
   ansible.builtin.template:
     src: go.d/plugin.conf.j2
     dest: "{{ netdata_config_dir }}/go.d/{{ item.name }}.conf"
-    owner: root
-    group: netdata
-    mode: '0644'
+    owner: "{{ netdata_config_owner }}"
+    group: "{{ netdata_config_group }}"
+    mode: "{{ netdata_config_mode }}"
   loop: "{{ netdata_go_collector_plugins }}"
   loop_control:
     label: "{{ item.name | default(omit) }}"
@@ -31,8 +31,8 @@
     dest: >-
       {{ netdata_chart_dir }}/{{ item | basename
       | regex_replace('\.j2$', '') }}
-    owner: root
-    group: netdata
+    owner: "{{ netdata_config_owner }}"
+    group: "{{ netdata_config_group }}"
     mode: '0750'
   loop: >-
     {{ lookup('fileglob',

--- a/tasks/node_claim.yml
+++ b/tasks/node_claim.yml
@@ -4,7 +4,7 @@
   ansible.builtin.template:
     src: claim.conf.j2
     dest: "{{ netdata_config_dir }}/claim.conf"
-    owner: root
-    group: root
-    mode: '0644'
+    owner: "{{ netdata_config_owner }}"
+    group: "{{ netdata_config_group }}"
+    mode: '0640'
   notify: Reload Netdata claiming state


### PR DESCRIPTION
Hi team,
quick and easy PR here.  Some systems may use a different user for the netdata agent, abstracting it out into defaults allows this to be overridden.

I've also tweaked the claim.conf mode from 0644 to 0640 for a tiny security boost - this file doesn't need to be world-readable.

Thanks in advance

Rawiri